### PR TITLE
wethr changed to bin/wethr

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,7 +14,7 @@ confinement: devmode
 
 apps:
   wethr:
-    command: wethr
+    command: bin/wethr
 
 parts:
   wethr:


### PR DESCRIPTION
- bin was not in path causing error to say wethr could not be found

> /snap/wethr/x2/command-wethr.wrapper: 2: exec: wethr: not found